### PR TITLE
Improve fixtures performance

### DIFF
--- a/flask_fixtures/__init__.py
+++ b/flask_fixtures/__init__.py
@@ -13,7 +13,6 @@ from __future__ import absolute_import
 
 import logging
 import os
-import time
 
 from sqlalchemy import Table
 

--- a/flask_fixtures/__init__.py
+++ b/flask_fixtures/__init__.py
@@ -94,7 +94,6 @@ def setup(obj):
     # Rollback any lingering transactions
     obj.db.session.rollback()
 
-
     # Construct a list of paths within which fixtures may reside
     default_fixtures_dir = os.path.join(current_app.root_path, 'fixtures')
 
@@ -155,13 +154,11 @@ def load_fixtures(db, fixtures):
 def delete_fixtures(db):
     """Deletes the loaded fixtures from database
     """
-    conn = db.engine.connect()
-
     # reversing the tables to ensure that dependendent table gets deleted first
-    for table in reversed(_fixture_tables):
-        # delete the tables loaded in this fixture
-        conn.execute(table.delete())
-        _fixture_tables.remove(table)
+    table_list = ''.join(reversed(['%s, ' % table.name for table in _fixture_tables]))[:-2]
+    db.session.execute('TRUNCATE TABLE %s RESTART IDENTITY CASCADE;' % table_list)
+    db.session.commit()
+    del _fixture_tables[:]
 
 
 class MetaFixturesMixin(type):

--- a/flask_fixtures/__init__.py
+++ b/flask_fixtures/__init__.py
@@ -176,6 +176,7 @@ class MetaFixturesMixin(type):
     @staticmethod
     def setup_handler(setup_fixtures_fn, setup_fn):
         """Returns a function that adds fixtures handling to the setup method.
+
         Makes sure that fixtures are setup before calling the given setup method.
         """
         def handler(obj):
@@ -203,6 +204,7 @@ class MetaFixturesMixin(type):
         an exception is raised, if one is found, it is returned, and if none are
         found, a function that calls the default method on each parent class is
         returned.
+
         """
         def call_method(obj, method):
             """Calls a method as either a class method or an instance method.

--- a/flask_fixtures/__init__.py
+++ b/flask_fixtures/__init__.py
@@ -1,9 +1,11 @@
 """
     flask.ext.fixtures
     ~~~~~~~~~~~~~~~~~~
+
     Flask-Fixtures is a `Flask <http://flask.pocoo.org>`_ extension that aids
     in the creation of fixtures data from serialized data files. It is
     compatible with the `SQLAlchemy <http://sqlalchemy.org>`_ library.
+
     :copyright: (c) 2015 Christopher Roach <ask.croach@gmail.com>.
     :license: MIT, see LICENSE for more details.
 """
@@ -49,6 +51,7 @@ TEST_TEARDOWN_NAMES = ('tearDown',)
 
 def push_ctx(app=None):
     """Creates new test context(s) for the given app
+
     If the app is not None, it overrides any existing app and/or request
     context. In other words, we will use the app that was passed in to create
     a new test request context on the top of the stack. If, however, nothing
@@ -56,6 +59,7 @@ def push_ctx(app=None):
     already in place and use that to run the test suite. If no app or request
     context can be found, an AssertionError is emitted to let the user know
     that they must somehow specify an application for testing.
+
     """
     if app is not None:
         ctx = app.test_request_context()
@@ -115,6 +119,7 @@ def setup(obj):
 
 
 def teardown(obj):
+    log.info('tearing down fixtures...')
     pop_ctx()
 
 
@@ -181,6 +186,7 @@ class MetaFixturesMixin(type):
     @staticmethod
     def teardown_handler(teardown_fixtures_fn, teardown_fn):
         """Returns a function that adds fixtures handling to the teardown method.
+
         Calls the given teardown method first before calling the fixtures teardown.
         """
         def handler(obj):
@@ -191,6 +197,7 @@ class MetaFixturesMixin(type):
     @staticmethod
     def get_child_fn(attrs, names, bases):
         """Returns a function from the child class that matches one of the names.
+
         Searches the child class's set of methods (i.e., the attrs dict) for all
         the functions matching the given list of names. If more than one is found,
         an exception is raised, if one is found, it is returned, and if none are
@@ -245,3 +252,4 @@ class FixturesMixin(six.with_metaclass(MetaFixturesMixin, object)):
     fixtures = None
     app = None
     db = None
+

--- a/flask_fixtures/utils.py
+++ b/flask_fixtures/utils.py
@@ -82,4 +82,3 @@ def can_persist_fixtures():
     filename = inspect.stack()[-1][1]
     executable = os.path.split(filename)[1]
     return executable in ('py.test', 'nosetests')
-

--- a/flask_fixtures/utils.py
+++ b/flask_fixtures/utils.py
@@ -82,3 +82,4 @@ def can_persist_fixtures():
     filename = inspect.stack()[-1][1]
     executable = os.path.split(filename)[1]
     return executable in ('py.test', 'nosetests')
+

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ except ImportError:
 
 setup(
     name='Flask-Fixtures',
-    version='0.3.7',
+    version='0.3.9',
     url='https://github.com/croach/Flask-Fixtures',
     license='MIT License',
     author='Christopher Roach',


### PR DESCRIPTION
- Instead of db.drop_all() and db.create_all(), use truncate to clear the tables
- Don't load fixtures from filesystem for every test, reuse the already loaded fixtures
- Truncate logic will be with the tests themselves.